### PR TITLE
Made versioning for requests less strict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
 
     packages=find_packages(),
     install_requires=[
-        "requests==2.32.3",
+        "requests>=2.32, <3.0",
         "munch==4.0",
         "jsonpickle>=1.0, <1.4",
         "future==1.0.0",


### PR DESCRIPTION
### 📖  Summary
The current versioning policy requires strict versions for all dependencies, which was added [here](https://github.com/seatsio/seatsio-python/pull/56).

Having a strict versioning policy on `requests` means that, whenever Dependabot opens a PR to bump either of those dependencies in our projects, it's unable to update any of them because we are forced to use the `requests` version that `seatsio` requires. The error is something like this:

```
ERROR: Cannot install -r requirements.txt and requests==2.31.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested requests==2.31.0
    seatsio 76.7.0 depends on requests==2.32.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

This means that seatsio `76.7.0` is only compatible with requests `2.32.0`, and seatsio `76.6.0` (our current version) is only compatible with requests `2.31.0` (also our current version), and **there's no way of updating them independently**.

### 💡 Proposed changes
Make versioning for requests less strict, allowing dependent projects to use any version of `requests` greater than or equal to `2.32`. For making the code future-proof, the upper limit can be set to `3.0`, where there could be potentially breaking changes in `requests`.