### PR TITLE
use new RELEASE statusChangeCommand type instead of hardcoded FREE status, when releasing objects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.8', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -21,8 +21,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
         python setup.py install
     - uses: zcong1993/setup-timezone@master
       with:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build](https://github.com/seatsio/seatsio-python/workflows/Build/badge.svg)](https://github.com/seatsio/seatsio-python/actions/workflows/build.yml)
 [![PyPI version](https://badge.fury.io/py/seatsio.svg)](https://badge.fury.io/py/seatsio)
 
-This is the official Python client library for the [Seats.io V2 REST API](https://docs.seats.io/docs/api-overview), supporting Python 3.7+. 
+This is the official Python client library for the [Seats.io V2 REST API](https://docs.seats.io/docs/api-overview), supporting Python 3.8+. 
 
 ## Installing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-importlib_metadata>=1.7.0;python_version<'3.8'

--- a/seatsio/events/eventsClient.py
+++ b/seatsio/events/eventsClient.py
@@ -10,6 +10,7 @@ from seatsio.events.createSingleEventRequest import CreateSingleEventRequest
 from seatsio.events.extraDataRequest import ExtraDataRequest
 from seatsio.events.forSaleRequest import ForSaleRequest
 from seatsio.events.overrideSeasonObjectStatusRequest import OverrideSeasonObjectStatusRequest
+from seatsio.events.releaseObjectsRequest import ReleaseObjectsRequest
 from seatsio.events.updateEventRequest import UpdateEventRequest
 from seatsio.pagination.listableObjectsClient import ListableObjectsClient
 from seatsio.pagination.lister import Lister
@@ -131,8 +132,10 @@ class EventsClient(ListableObjectsClient):
 
     def release(self, event_key_or_keys, object_or_objects, hold_token=None, order_id=None, keep_extra_data=None,
                 ignore_channels=None, channel_keys=None):
-        return self.change_object_status(event_key_or_keys, object_or_objects, EventObjectInfo.FREE, hold_token,
-                                         order_id, keep_extra_data, ignore_channels, channel_keys)
+        request = ReleaseObjectsRequest(
+            object_or_objects, hold_token, order_id, event_key_or_keys,
+            keep_extra_data, ignore_channels, channel_keys)
+        return self.__do_change_status(request)
 
     def hold(self, event_key_or_keys, object_or_objects, hold_token, order_id=None, keep_extra_data=None,
              ignore_channels=None, channel_keys=None):
@@ -146,6 +149,9 @@ class EventsClient(ListableObjectsClient):
         request = ChangeObjectStatusRequest(object_or_objects, status, hold_token, order_id, event_key_or_keys,
                                             keep_extra_data, ignore_channels, channel_keys,
                                             allowed_previous_statuses, rejected_previous_statuses)
+        return self.__do_change_status(request)
+
+    def __do_change_status(self, request):
         response = self.http_client.url("/events/groups/actions/change-object-status",
                                         query_params={"expand": "objects"}).post(request)
         return ChangeObjectStatusResult(response.json())

--- a/seatsio/events/releaseObjectsRequest.py
+++ b/seatsio/events/releaseObjectsRequest.py
@@ -3,11 +3,10 @@ from past.builtins import basestring
 from seatsio.events.objectProperties import ObjectProperties
 
 
-class ChangeObjectStatusRequest:
-    def __init__(self, object_or_objects, status, hold_token, order_id, event_key_or_keys, keep_extra_data, ignore_channels, channel_keys, allowed_previous_statuses=None, rejected_previous_statuses=None):
+class ReleaseObjectsRequest:
+    def __init__(self, object_or_objects, hold_token, order_id, event_key_or_keys, keep_extra_data, ignore_channels, channel_keys, allowed_previous_statuses=None, rejected_previous_statuses=None):
         self.objects = self.__normalize_objects(object_or_objects)
-        self.type = 'CHANGE_STATUS_TO'
-        self.status = status
+        self.type = 'RELEASE'
         if hold_token:
             self.holdToken = hold_token
         if order_id:


### PR DESCRIPTION
Instead of passing in FREE as a status, we now use RELEASE as statusChangeCommand type.
That way, objects that were in RESALE status before, will be released to status RESALE, and not to FREE.