### PR TITLE
Remove update chart key for event

### DIFF
--- a/seatsio/events/eventsClient.py
+++ b/seatsio/events/eventsClient.py
@@ -36,10 +36,10 @@ class EventsClient(ListableObjectsClient):
             CreateMultipleEventsRequest(chart_key, events_properties))
         return Event.create_list(response.json().get("events"))
 
-    def update(self, key, chart_key=None, event_key=None, name=None, date=None, table_booking_config=None,
+    def update(self, key, event_key=None, name=None, date=None, table_booking_config=None,
                object_categories=None, categories=None, is_in_the_past=None):
-        request = UpdateEventRequest(chart_key, event_key, name, date, table_booking_config, object_categories,
-                                     categories, is_in_the_past)
+        request = UpdateEventRequest(event_key, name, date, table_booking_config, object_categories, categories,
+                                     is_in_the_past)
         self.http_client.url("/events/{key}", key=key).post(
             request)
 

--- a/seatsio/events/updateEventRequest.py
+++ b/seatsio/events/updateEventRequest.py
@@ -2,8 +2,8 @@ from seatsio.events.createSingleEventRequest import CreateSingleEventRequest
 
 
 class UpdateEventRequest(CreateSingleEventRequest):
-    def __init__(self, chart_key, event_key=None, name=None, date=None, table_booking_config=None,
+    def __init__(self, event_key=None, name=None, date=None, table_booking_config=None,
                  object_categories=None, categories=None, is_in_the_past=None):
-        CreateSingleEventRequest.__init__(self, chart_key, event_key, name, date, table_booking_config, object_categories, categories)
+        CreateSingleEventRequest.__init__(self, None, event_key, name, date, table_booking_config, object_categories, categories)
         if is_in_the_past is not None:
             self.isInThePast = is_in_the_past

--- a/tests/events/testUpdateEvent.py
+++ b/tests/events/testUpdateEvent.py
@@ -1,24 +1,11 @@
 from datetime import datetime, date
 
 from seatsio import TableBookingConfig, Category
-from seatsio.exceptions import SeatsioException
 from tests.seatsioClientTest import SeatsioClientTest
 from tests.util.asserts import assert_that
 
 
 class UpdateEventTest(SeatsioClientTest):
-
-    def test_updateChartKey(self):
-        chart1 = self.client.charts.create()
-        event = self.client.events.create(chart1.key)
-        chart2 = self.client.charts.create()
-
-        self.client.events.update(event.key, chart_key=chart2.key)
-
-        retrieved_event = self.client.events.retrieve(event.key)
-        assert_that(retrieved_event.key).is_equal_to(event.key)
-        assert_that(retrieved_event.chart_key).is_equal_to(chart2.key)
-        assert_that(retrieved_event.updated_on).is_between_now_minus_and_plus_minutes(datetime.utcnow(), 1)
 
     def test_updateEventKey(self):
         chart = self.client.charts.create()


### PR DESCRIPTION
Updating the chart key of an event is no longer documented but is still supported by the client libraries. This PR removes the parameter from `updateEventRequest`.