### PR TITLE
Distinct exception type thrown when best available objects not found

### DIFF
--- a/seatsio/exceptions.py
+++ b/seatsio/exceptions.py
@@ -15,6 +15,13 @@ class SeatsioException(Exception):
             self.message = "Error while executing " + request.http_method + " " + request.url
             super(SeatsioException, self).__init__(self.message)
 
+    @staticmethod
+    def from_response(request, response, cause=None):
+        if response.status_code == 429:
+            return RateLimitExceededException(request, response)
+        else:
+            return SeatsioException(request, response)
+
     def __build_exception_message(self):
         return ", ".join(self.__map_errors_to_message(self.errors)) + "."
 

--- a/seatsio/exceptions.py
+++ b/seatsio/exceptions.py
@@ -26,3 +26,8 @@ class RateLimitExceededException(SeatsioException):
 
     def __init__(self, request, response=None, cause=None):
         super(RateLimitExceededException, self).__init__(request, response, cause)
+
+class BestAvailableObjectsNotFoundException(SeatsioException):
+
+    def __init__(self, request, response=None, cause=None):
+        super(BestAvailableObjectsNotFoundException, self).__init__(request, response, cause)

--- a/seatsio/exceptions.py
+++ b/seatsio/exceptions.py
@@ -16,11 +16,26 @@ class SeatsioException(Exception):
             super(SeatsioException, self).__init__(self.message)
 
     @staticmethod
-    def from_response(request, response, cause=None):
+    def from_response(request, response):
         if response.status_code == 429:
             return RateLimitExceededException(request, response)
+        elif SeatsioException.__is_best_available_objects_not_found(response):
+            return BestAvailableObjectsNotFoundException(request, response)
         else:
             return SeatsioException(request, response)
+
+    @staticmethod
+    def __is_best_available_objects_not_found(response):
+        if "application/json" not in response.headers.get("content-type", ""):
+            return False
+        body = response.json()
+        if "errors" not in body:
+            return False
+        for error in body["errors"]:
+            if isinstance(error, dict) and 'code' in error:
+                if error['code'] == 'BEST_AVAILABLE_OBJECTS_NOT_FOUND':
+                    return True
+        return False
 
     def __build_exception_message(self):
         return ", ".join(self.__map_errors_to_message(self.errors)) + "."

--- a/seatsio/httpClient.py
+++ b/seatsio/httpClient.py
@@ -8,10 +8,7 @@ from seatsio.exceptions import SeatsioException, RateLimitExceededException
 
 
 def handle_error(request, response):
-    if response.status_code == 429:
-        raise RateLimitExceededException(request, response)
-    else:
-        raise SeatsioException(request, response)
+    raise SeatsioException.from_response(request, response)
 
 
 class HttpClient:

--- a/tests/events/testChangeBestAvailableObjectStatus.py
+++ b/tests/events/testChangeBestAvailableObjectStatus.py
@@ -1,4 +1,5 @@
 from seatsio.domain import EventObjectInfo, Channel
+from seatsio.exceptions import BestAvailableObjectsNotFoundException, SeatsioException
 from tests.seatsioClientTest import SeatsioClientTest
 from tests.util.asserts import assert_that
 
@@ -200,3 +201,18 @@ class ChangeBestAvailableObjectStatusTest(SeatsioClientTest):
         result = self.client.events.change_best_available_object_status(event.key, 3, "myStatus", accessible_seats=1)
         assert_that(result.next_to_each_other).is_true()
         assert_that(result.objects).contains_exactly("A-6", "A-7", "A-8")
+
+    def test_throwsBestAvailableObjectsNotFoundException(self):
+        chart_key = self.create_test_chart()
+        event = self.client.events.create(chart_key)
+        try :
+            self.client.events.change_best_available_object_status(event.key, 3000, "myStatus")
+            self.fail("expected exception")
+        except BestAvailableObjectsNotFoundException as e:
+            assert_that(e.message).is_equal_to("No best available objects found")
+
+    def test_genericSeatsioExceptionWhenEventNotFound(self):
+        try :
+            self.client.events.change_best_available_object_status("unexisting_event", 3000, "myStatus")
+        except SeatsioException as e:
+            assert_that(e).is_not_instance(BestAvailableObjectsNotFoundException)

--- a/tests/events/testChangeBestAvailableObjectStatus.py
+++ b/tests/events/testChangeBestAvailableObjectStatus.py
@@ -209,7 +209,7 @@ class ChangeBestAvailableObjectStatusTest(SeatsioClientTest):
             self.client.events.change_best_available_object_status(event.key, 3000, "myStatus")
             self.fail("expected exception")
         except BestAvailableObjectsNotFoundException as e:
-            assert_that(e.message).is_equal_to("No best available objects found")
+            assert_that(e.message).is_equal_to("Best available objects not found.")
 
     def test_genericSeatsioExceptionWhenEventNotFound(self):
         try :

--- a/tests/util/asserts.py
+++ b/tests/util/asserts.py
@@ -31,6 +31,11 @@ class AbstractAssert():
             type(self.actual))
         return self
 
+    def is_not_instance(self, cls):
+        assert not isinstance(self.actual, cls), "expected actual to not be of type " + str(cls) + ", but was " + str(
+            type(self.actual))
+        return self
+
     def is_none(self):
         assert self.actual is None, "expected actual to be None, but it was not: " + str(self.actual)
 


### PR DESCRIPTION
Instead of throwing a generic SeatsioException (which is thrown in many cases, eg no focal point, event not found, etc), we now throw a BestAvailableObjectsNotFoundException (subclass of SeatsioException) to make it easier to handle this common specific case.