### PR TITLE
Move event to a new chart copy

### DIFF
--- a/seatsio/events/eventsClient.py
+++ b/seatsio/events/eventsClient.py
@@ -219,3 +219,7 @@ class EventsClient(ListableObjectsClient):
         self.http_client \
             .url("/events/{key}/actions/update-extra-data", key=key) \
             .post(ExtraDataRequest(extra_datas))
+
+    def move_event_to_new_chart_copy(self, event_key: str):
+        response = self.http_client.url("/events/{event_key}/actions/move-to-new-chart-copy", event_key=event_key).post()
+        return Event(response.json())

--- a/tests/events/testMoveEventToNewChartCopy.py
+++ b/tests/events/testMoveEventToNewChartCopy.py
@@ -1,0 +1,13 @@
+from tests.seatsioClientTest import SeatsioClientTest
+from tests.util.asserts import assert_that
+
+class MoveEventToNewChartCopyTest(SeatsioClientTest):
+
+    def test_event_is_moved_to_new_chart_copy(self):
+        chart = self.client.charts.create()
+        event = self.client.events.create(chart.key)
+
+        moved_event = self.client.events.move_event_to_new_chart_copy(event.key)
+
+        assert_that(moved_event.chart_key).is_not_equal_to(event.chart_key)
+        assert_that(moved_event.key).is_equal_to(event.key)


### PR DESCRIPTION
Creates a new copy of the chart the event belongs to, and moves the event to that chart.